### PR TITLE
Two small fixes

### DIFF
--- a/hound.py
+++ b/hound.py
@@ -136,7 +136,7 @@ class HoundSearchCommand(HoundBaseCommand):
             data = data.encode('utf-8') # data should be bytes
         else:
             data = None
-        req = urllib.request.urlopen(url, data)
+        req = urllib.request.urlopen(urllib.request.Request(url, data, headers=self.custom_headers))
         encoding = req.headers.get_content_charset()
         response_data = req.read().decode(encoding)
         if self.debug:

--- a/hound.py
+++ b/hound.py
@@ -21,7 +21,7 @@ SETTINGS = "Hound.sublime-settings"
 class HoundBaseCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         self.settings = sublime.load_settings(SETTINGS)
-        self.hound_url = self.settings.get("hound_url")
+        self.hound_url = self.settings.get("hound_url").rstrip("/")
         self.github_base_url = self.settings.get("github_base_url")
         self.exclude_repos = set(self.settings.get("exclude_repos", []))
         self.custom_headers = self.settings.get("custom_headers", {})


### PR DESCRIPTION
- Use the custom headers.
- Remove trailing slash from hound_url if found.

I'd see if I can generalise the plugin to make it work with other than GitHub, currently it doesn't work for me at work, I might spend some time on this.
